### PR TITLE
Remove stray character for valid JSON syntax

### DIFF
--- a/config.json.example
+++ b/config.json.example
@@ -8,5 +8,5 @@
     "username": "", 
     "password": "",
     "enrollment_location_id": "",
-    "init_url": "https://goes-app.cbp.dhs.gov/main/goes",
+    "init_url": "https://goes-app.cbp.dhs.gov/main/goes"
 }


### PR DESCRIPTION
If you copy the config.json.example as instructed then the script exits with message "Could not find config.json" because the syntax is invalid.  JSON.parse is throwing an exception due to the trailing comma.
