### PR TITLE
Limited password to 12 characters to fix 'Unable to find terms accept…

### DIFF
--- a/ge-cancellation-checker.phantom.js
+++ b/ge-cancellation-checker.phantom.js
@@ -82,7 +82,10 @@ var steps = [
         page.evaluate(function() {
             console.log('On GOES login page...');
             document.querySelector('input[name=username]').value = window.callPhantom('username');
-            document.querySelector('input[name=password]').value = window.callPhantom('password');
+
+            /* The GE Login page limits passwords to only 12 characters, but phantomjs can get around 
+               this limitation, which causes the fatal error "Unable to find terms acceptance button" */
+            document.querySelector('input[name=password]').value = window.callPhantom('password').substring(0,12);
             document.querySelector('form[action="/pkmslogin.form"]').submit();
             console.log('Logging in...');
         });


### PR DESCRIPTION
The GE Login page limits passwords to only 12 characters, but phantomjs can get around this limitation,
which causes the fatal error "Unable to find terms acceptance button". Limiting the password to 12 characters fixes this issue. (While the GE system appears to accept more than 12 characters, the database only stored the first 12 characters when you signed up.)
