### PR TITLE
Update cron checker shebang for compatibility

### DIFF
--- a/ge-checker-cron.py
+++ b/ge-checker-cron.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 # Note: for setting up email with sendmail, see: http://linuxconfig.org/configuring-gmail-as-sendmail-email-relay
 


### PR DESCRIPTION
I noticed this on FreeBSD, which installs python into `/usr/local/bin/python`. Using `/usr/bin/env` should find the correct python executable as long as it's in your `PATH`.

I saw in CONTRIBUTING.md that I'm supposed to do pull requests from the `dev` branch, but it looks like recent PRs were done from `master` and `dev` is currently a bunch of commits behind as well. So I hope this is okay!
