### PR TITLE
Add support for SMS notifications via Twilio

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,19 @@ To get started, copy `config.json.example` to `config.json`. In your new config,
 
 * **init_url**: the login page of the GOES website.
 
+* **twilio_account_sid** (optional): the account SID for your Twilio account, if you want to receive SMS notifications. See [the next section](#twilio-sms-notification) for details.
+
+* **twilio_auth_token** (optional): the auth token for your Twilio account, if you want to receive SMS notifications. See [the next section](#twilio-sms-notification) for details.
+
+* **twilio_from_number** (optional): the phone number from which to send SMS notifications. See [the next section](#twilio-sms-notification) for details.
+
+* **twilio_to_number** (optional): the phone number to which to send SMS notifications – this is probably *your* phone number! See [the next section](#twilio-sms-notification) for details.
+
 Please also ensure you are the only one with access to your `config.json` to protect your username and password.
+
+### Twilio SMS Notification ###
+
+If you'd like to receive SMS notifications in addition to or instead of email notifications, you can do so with [Twilio](https://twilio.com). Create an account and a new SMS enabled sending phone number, then fill in `twilio_account_sid`, `twilio_auth_token`, `twilio_from_number`, and `twilio_to_number` in `config.json`. The from and to phone numbers should be formatted like this: `+18005551234`
 
 ### Scheduling ###
 

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Please also ensure you are the only one with access to your `config.json` to pro
 
 ### Twilio SMS Notification ###
 
-If you'd like to receive SMS notifications in addition to or instead of email notifications, you can do so with [Twilio](https://twilio.com). Create an account and a new SMS enabled sending phone number, then fill in `twilio_account_sid`, `twilio_auth_token`, `twilio_from_number`, and `twilio_to_number` in `config.json`. The from and to phone numbers should be formatted like this: `+18005551234`
+If you'd like to receive SMS notifications in addition to or instead of email notifications, you can do so with [Twilio](https://twilio.com). Create an account and a new SMS enabled sending phone number, then fill in `twilio_account_sid`, `twilio_auth_token`, `twilio_from_number`, and `twilio_to_number` in `config.json`. The from and to phone numbers should be formatted like this: `+18005551234`. You'll also need to install the `twilio` Python package, with `pip install twilio`.
 
 ### Scheduling ###
 

--- a/config.json.example
+++ b/config.json.example
@@ -18,6 +18,6 @@
 
     "twilio_account_sid": "",
     "twilio_auth_token": "",
-    "twilio_from_number": "",
-    "twilio_to_number": ""
+    "twilio_from_number": "example: +18005551234",
+    "twilio_to_number": "example: +18005551234"
 }

--- a/config.json.example
+++ b/config.json.example
@@ -13,6 +13,11 @@
     "__comment": "Below are optional:",
     "use_gmail": false,
     "gmail_password": "<only required if use_gmail is true>",
-    "no_email": false,                                                                                                                                                
-    "notify_osx": false
+    "no_email": false,
+    "notify_osx": false,
+
+    "twilio_account_sid": "",
+    "twilio_auth_token": "",
+    "twilio_from_number": "",
+    "twilio_to_number": ""
 }


### PR DESCRIPTION
Hi! I kept missing the notification emails, so I hacked in support to send SMS notifications with Twilio. I didn't even pay for it – I just used Twilio's trial mode, which works fine for this application. I figure this might be useful for other people, so here's this PR. It includes:
- Add `notify_sms` function that tries to use `TwilioRestClient` to send an SMS, and fails gracefully if the `twilio` package is not available
- Add log level name to logging format
- Change one error print to a logging call
- Add optional parameters to `config.json.example`
- Add SMS documentation to `README.md`

Let me know if there's anything I should change, happy to respond to comments! Also let me know if you don't think this functionality is useful to enough people, and I'll abandon the PR. 
