### PR TITLE
Feature/custom config

### DIFF
--- a/ge-cancellation-checker.phantom.js
+++ b/ge-cancellation-checker.phantom.js
@@ -17,23 +17,33 @@ else {
     PWD = current_path_arr.join('/');
 }
 
-// Gather Settings...
+
+
+// ...from command
+var configFile = PWD + '/config.json'
+system.args.forEach(function(val, i) {
+    if (val == '-v' || val == '--verbose') { VERBOSE = true; }
+    if (val == '--config') {
+	if (system.args.length == i) console.log('failed to set config - no option given');
+	else {
+	    configFile = system.args[i+1];
+	}
+    }
+});
+
+
 try {
-    var settings = JSON.parse(fs.read(PWD + '/config.json'));
+    var settings = JSON.parse(fs.read(configFile));
     if (!settings.username || !settings.username || !settings.init_url || !settings.enrollment_location_id) {
         console.log('Missing username, password, enrollment location ID, and/or initial URL. Exiting...');
         phantom.exit();
     }
 }
 catch(e) {
-    console.log('Could not find config.json');
+    console.log('Could not find ' + configFile);
     phantom.exit();
 }
 
-// ...from command
-system.args.forEach(function(val, i) {
-    if (val == '-v' || val == '--verbose') { VERBOSE = true; }
-});
 
 function fireClick(el) {
     var ev = document.createEvent("MouseEvents");

--- a/ge-checker-cron.py
+++ b/ge-checker-cron.py
@@ -86,7 +86,7 @@ def main(settings):
     try:
         # Run the phantom JS script - output will be formatted like 'July 20, 2015'
         # script_output = check_output(['phantomjs', '%s/ge-cancellation-checker.phantom.js' % pwd]).strip()
-        script_output = check_output(['phantomjs', '--ssl-protocol=any', '%s/ge-cancellation-checker.phantom.js' % pwd]).strip()
+        script_output = check_output(['/usr/local/bin/phantomjs', '--ssl-protocol=any', '%s/ge-cancellation-checker.phantom.js' % pwd, '--config', settings.get('configfile')]).strip()
         
         if script_output == 'None':
             logging.info('No appointments available.')
@@ -102,9 +102,9 @@ def main(settings):
 
     current_apt = datetime.strptime(settings['current_interview_date_str'], '%B %d, %Y')
     if new_apt > current_apt:
-        logging.info('No new appointments. Next available on %s (current is on %s)' % (new_apt, current_apt))
+        logging.info('No new appointments. Next available in location %s on %s (current is on %s)' % (settings.get("enrollment_location_id"), new_apt, current_apt))
     else:
-        msg = 'Found new appointment on %s (current is on %s)!' % (new_apt, current_apt)
+        msg = 'Found new appointment in location %s on %s (current is on %s)!' % (settings.get("enrollment_location_id"), new_apt, current_apt)
         logging.info(msg + (' Sending email.' if not settings.get('no_email') else ' Not sending email.'))
 
         if settings.get('notify_osx'):
@@ -153,7 +153,7 @@ if __name__ == '__main__':
     parser.add_argument('--notify-osx', action='store_true', dest='notify_osx', default=False, help='If better date is found, notify on the osx desktop.')
     parser.add_argument('--config', dest='configfile', default='%s/config.json' % pwd, help='Config file to use (default is config.json)')
     arguments = vars(parser.parse_args())
-
+    logging.info("config file is:" + arguments['configfile'])
     # Load Settings
     try:
         with open(arguments['configfile']) as json_file:
@@ -163,7 +163,8 @@ if __name__ == '__main__':
             for key, val in arguments.iteritems():
                 if not arguments.get(key): continue
                 settings[key] = val
-
+            
+            settings['configfile'] = arguments['configfile']
             _check_settings(settings)
     except Exception as e:
         logging.error('Error loading settings from config.json file: %s' % e)

--- a/ge-checker-cron.py
+++ b/ge-checker-cron.py
@@ -86,7 +86,7 @@ def main(settings):
     try:
         # Run the phantom JS script - output will be formatted like 'July 20, 2015'
         # script_output = check_output(['phantomjs', '%s/ge-cancellation-checker.phantom.js' % pwd]).strip()
-        script_output = check_output(['/usr/local/bin/phantomjs', '--ssl-protocol=any', '%s/ge-cancellation-checker.phantom.js' % pwd, '--config', settings.get('configfile')]).strip()
+        script_output = check_output(['phantomjs', '--ssl-protocol=any', '%s/ge-cancellation-checker.phantom.js' % pwd, '--config', settings.get('configfile')]).strip()
         
         if script_output == 'None':
             logging.info('No appointments available.')


### PR DESCRIPTION
Added the ability to actually use different config files (before, if you used a config file other than config.json, the python script would take settings from the custom config, but the phantomjs script would use config.json no matter what, which I found confusing until I figured out what was going on). I wanted to be able to check multiple locations with different dates - with this change I can add a config file per location, and then have one line per config in my crontab. There are perhaps more elegant ways of doing multiple locations, but I also thought it was good to have setting the config file behave as you might expect. I have tested this to the best of my ability and it should let you use any config file placed anywhere, and config.json doesn't have to exist if you set the config option manually.