### PR TITLE
Added email settings to allow better configuration

### DIFF
--- a/config.json.example
+++ b/config.json.example
@@ -4,6 +4,8 @@
      
     "email_from": "",
     "email_to": [],
+    "email_host": "localhost",
+    "email_port": 25,
 
     "username": "", 
     "password": "",

--- a/ge-checker-cron.py
+++ b/ge-checker-cron.py
@@ -36,7 +36,7 @@ def notify_send_email(settings, current_apt, avail_apt, use_gmail=False):
             server.starttls()
             server.login(sender, password)
         else:
-            server = smtplib.SMTP('localhost', 25)
+            server = smtplib.SMTP(settings.get('email_host', 'localhost'), settings.get('email_port', 25))
 
         subject = "Alert: New Global Entry Appointment Available"
         headers = "\r\n".join(["from: %s" % sender,


### PR DESCRIPTION
Added the following settings:
	"email_host" which will allow you to set a value other than "localhost" (defaults to localhost)
	"email_port" which will allow you to set a value other than "25" (defaults to 25)