### PR TITLE
Updated 'phantomjs' path to absolute path

### DIFF
--- a/ge-checker-cron.py
+++ b/ge-checker-cron.py
@@ -86,7 +86,7 @@ def main(settings):
     try:
         # Run the phantom JS script - output will be formatted like 'July 20, 2015'
         # script_output = check_output(['phantomjs', '%s/ge-cancellation-checker.phantom.js' % pwd]).strip()
-        script_output = check_output(['phantomjs', '--ssl-protocol=any', '%s/ge-cancellation-checker.phantom.js' % pwd, '--config', settings.get('configfile')]).strip()
+        script_output = check_output(['/usr/local/bin/phantomjs', '--ssl-protocol=any', '%s/ge-cancellation-checker.phantom.js' % pwd, '--config', settings.get('configfile')]).strip()
         
         if script_output == 'None':
             logging.info('No appointments available.')


### PR DESCRIPTION
Struggled for a while trying to get this to schedule properly.  I could run the script fine manually through terminal but when crontab scheduling, it struggled to find phantomjs.  Changing the launcher to use the full path '/usr/local/bin/phantomjs' instead of just 'phantomjs' fixed my issue.  If you feel this was just my own local mac issue and don't think this commit is necessary, it might be worth at least adding some help documentation on trying to use 'usr/local/bin/phantomjs' instead of 'phantomjs' due to the amount of people attempting to use this that aren't tech-savvy.